### PR TITLE
add support for 'x' as a step token as well as '@'

### DIFF
--- a/src/frame_format_grammar.pest
+++ b/src/frame_format_grammar.pest
@@ -1,6 +1,6 @@
 PositiveNumber = { ASCII_DIGIT+ }
 Frame = { ("+" | "-")? ~ PositiveNumber }
-StepSymbol = { "@" }
+StepSymbol = { "@" | "x" }
 BinarySequenceSymbol = { "b" }
 FrameRange = { Frame ~ "-" ~ Frame ~ ( StepSymbol ~ ( PositiveNumber | BinarySequenceSymbol ) )? }
 FrameSequencePart = { FrameRange | Frame }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,4 +206,18 @@ mod tests {
             frames.as_slice()
         );
     }
+    
+    #[test]
+    fn test_multi_sequence() {
+        use crate::parse_frame_sequence;
+        let frames = parse_frame_sequence("10-20@2,42-33@3").unwrap();
+        assert_eq!([10, 12, 14, 16, 18, 20, 42, 39, 36, 33], frames.as_slice());
+    }
+    
+    #[test]
+    fn test_multi_sequence_x() {
+        use crate::parse_frame_sequence;
+        let frames = parse_frame_sequence("10-20x2,42-33x3").unwrap();
+        assert_eq!([10, 12, 14, 16, 18, 20, 42, 39, 36, 33], frames.as_slice());
+    }
 }


### PR DESCRIPTION
Adds support for Nuke-style 1-10x2 as well as 1-10@2. Adds a test for this as well as specifying multiple, stepped ranges.